### PR TITLE
Add stable argsort option

### DIFF
--- a/src/haliax/__init__.py
+++ b/src/haliax/__init__.py
@@ -715,7 +715,9 @@ def nanmean(
     where: Optional[NamedArray] = None,
     dtype: Optional[DTypeLike] = None,
 ) -> NamedArray:
-    return wrap_reduction_call(jnp.nanmean, array, axis, where, single_axis_only=False, supports_where=True, dtype=dtype)
+    return wrap_reduction_call(
+        jnp.nanmean, array, axis, where, single_axis_only=False, supports_where=True, dtype=dtype
+    )
 
 
 def nanmin(
@@ -734,7 +736,9 @@ def nanprod(
     where: Optional[NamedArray] = None,
     dtype: Optional[DTypeLike] = None,
 ) -> NamedArray:
-    return wrap_reduction_call(jnp.nanprod, array, axis, where, single_axis_only=False, supports_where=True, dtype=dtype)
+    return wrap_reduction_call(
+        jnp.nanprod, array, axis, where, single_axis_only=False, supports_where=True, dtype=dtype
+    )
 
 
 def nanstd(
@@ -745,7 +749,9 @@ def nanstd(
     ddof: int = 0,
     dtype: Optional[DTypeLike] = None,
 ) -> NamedArray:
-    return wrap_reduction_call(jnp.nanstd, array, axis, where, single_axis_only=False, supports_where=True, dtype=dtype, ddof=ddof)
+    return wrap_reduction_call(
+        jnp.nanstd, array, axis, where, single_axis_only=False, supports_where=True, dtype=dtype, ddof=ddof
+    )
 
 
 def nansum(
@@ -755,7 +761,9 @@ def nansum(
     where: Optional[NamedArray] = None,
     dtype: Optional[DTypeLike] = None,
 ) -> NamedArray:
-    return wrap_reduction_call(jnp.nansum, array, axis, where, single_axis_only=False, supports_where=True, dtype=dtype)
+    return wrap_reduction_call(
+        jnp.nansum, array, axis, where, single_axis_only=False, supports_where=True, dtype=dtype
+    )
 
 
 def nanvar(
@@ -766,7 +774,9 @@ def nanvar(
     ddof: int = 0,
     dtype: Optional[DTypeLike] = None,
 ) -> NamedArray:
-    return wrap_reduction_call(jnp.nanvar, array, axis, where, single_axis_only=False, supports_where=True, dtype=dtype, ddof=ddof)
+    return wrap_reduction_call(
+        jnp.nanvar, array, axis, where, single_axis_only=False, supports_where=True, dtype=dtype, ddof=ddof
+    )
 
 
 # "Normalization" functions that use an axis but don't change the shape
@@ -807,14 +817,17 @@ def sort(a: NamedArray, axis: AxisSelector) -> NamedArray:
     return wrap_axiswise_call(jnp.sort, a, axis, single_axis_only=True)
 
 
-def argsort(a: NamedArray, axis: AxisSelector) -> NamedArray:
+def argsort(a: NamedArray, axis: AxisSelector | None, *, stable: bool = False) -> NamedArray:
     """
     Named version of [jax.numpy.argsort](https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.argsort.html).
 
     If `axis` is None, the returned array will be a 1D array of indices that would sort the flattened array,
     identical to `jax.numpy.argsort(a.array)`.
+
+    Args:
+        stable: If ``True``, ensures that the indices of equal elements preserve their relative order.
     """
-    return wrap_axiswise_call(jnp.argsort, a, axis, single_axis_only=True)
+    return wrap_axiswise_call(jnp.argsort, a, axis, single_axis_only=True, stable=stable)
 
 
 # elemwise binary ops

--- a/src/haliax/core.py
+++ b/src/haliax/core.py
@@ -623,8 +623,8 @@ class NamedArray(metaclass=NamedArrayMeta):
     def argmin(self, axis: Optional[AxisSelector]) -> "NamedArray":  # pragma: no cover
         return haliax.argmin(self, axis=axis)
 
-    def argsort(self, axis: AxisSelector) -> "NamedArray":  # pragma: no cover
-        return haliax.argsort(self, axis=axis)
+    def argsort(self, axis: AxisSelector | None, *, stable: bool = False) -> "NamedArray":  # pragma: no cover
+        return haliax.argsort(self, axis=axis, stable=stable)
 
     def astype(self, dtype) -> "NamedArray":  # pragma: no cover
         return NamedArray(self.array.astype(dtype), self.axes)

--- a/src/haliax/fft.py
+++ b/src/haliax/fft.py
@@ -1,3 +1,7 @@
+# Copyright 2025 The Levanter Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 """Named wrappers around :mod:`jax.numpy.fft`.
 
 These functions mirror the behaviour of their :mod:`jax.numpy.fft` counterparts
@@ -42,7 +46,6 @@ import jax.numpy.fft as jfft
 
 from .axis import Axis, AxisSelector, AxisSelection
 from .core import NamedArray
-
 
 AxisSizeLike = int | Axis | None
 AxisMapping = Mapping[AxisSelector, AxisSizeLike]

--- a/src/haliax/ops.py
+++ b/src/haliax/ops.py
@@ -127,9 +127,7 @@ def nonzero(array: NamedArray, *, size: Axis, fill_value: int = 0) -> tuple[Name
     if not isinstance(array, NamedArray):
         raise ValueError("array must be a NamedArray")
 
-    return tuple(
-        NamedArray(idx, (size,)) for idx in jnp.nonzero(array.array, size=size.size, fill_value=fill_value)
-    )
+    return tuple(NamedArray(idx, (size,)) for idx in jnp.nonzero(array.array, size=size.size, fill_value=fill_value))
 
 
 def clip(array: NamedOrNumeric, a_min: NamedOrNumeric, a_max: NamedOrNumeric) -> NamedArray:

--- a/tests/core_test.py
+++ b/tests/core_test.py
@@ -242,6 +242,25 @@ def test_cumsum_etc():
     assert jnp.all(jnp.equal(hax.argsort(named1, axis=Width).array, jnp.argsort(named1.array, axis=1)))
     assert hax.argsort(named1, axis=Width).axes == (Height, Width, Depth)
 
+    assert jnp.all(
+        jnp.equal(
+            hax.argsort(named1, axis=Height, stable=True).array,
+            jnp.argsort(named1.array, axis=0, stable=True),
+        )
+    )
+    assert jnp.all(
+        jnp.equal(
+            hax.argsort(named1, axis=Width, stable=True).array,
+            jnp.argsort(named1.array, axis=1, stable=True),
+        )
+    )
+    assert jnp.all(
+        jnp.equal(
+            hax.argsort(named1, axis=None, stable=True),
+            jnp.argsort(named1.array, axis=None, stable=True),
+        )
+    )
+
 
 def test_searchsorted():
     A = hax.Axis("a", 5)

--- a/tests/test_bitwise_ops.py
+++ b/tests/test_bitwise_ops.py
@@ -1,3 +1,7 @@
+# Copyright 2025 The Levanter Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import jax.numpy as jnp
 import haliax as hax
 from haliax import Axis

--- a/tests/test_fft.py
+++ b/tests/test_fft.py
@@ -1,3 +1,7 @@
+# Copyright 2025 The Levanter Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import jax.numpy as jnp
 import jax.numpy.fft as jfft
 
@@ -71,9 +75,7 @@ def test_fft_multi_axis():
     assert jnp.allclose(rf.array, jfft.rfftn(arr.array, axes=(1, 2)))
 
     irf = hax.irfft(rf, axis={"y": None, "z": Z})
-    assert jnp.allclose(
-        irf.array, jfft.irfftn(jfft.rfftn(arr.array, axes=(1, 2)), s=(Y.size, Z.size), axes=(1, 2))
-    )
+    assert jnp.allclose(irf.array, jfft.irfftn(jfft.rfftn(arr.array, axes=(1, 2)), s=(Y.size, Z.size), axes=(1, 2)))
 
     # resizing via dict values
     f2 = hax.fft(arr, axis={"y": 4, "z": None})

--- a/tests/test_nan_reductions.py
+++ b/tests/test_nan_reductions.py
@@ -1,3 +1,7 @@
+# Copyright 2025 The Levanter Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Any, Callable
 
 import jax.numpy as jnp


### PR DESCRIPTION
## Summary
- add a `stable` keyword to `haliax.argsort` and the corresponding `NamedArray.argsort` method so stable sorts can be requested
- extend the core tests to cover the new `stable` flag, including the `axis=None` case
- accept pre-commit formatting updates and SPDX headers required by repository hooks

## Testing
- uv run pre-commit run --all-files

------
https://chatgpt.com/codex/tasks/task_e_68cad86ec3a083319493c24a774ce00a