### PR TITLE
Refine polynomial wrappers and typings

### DIFF
--- a/.agents/projects/api_parity.md
+++ b/.agents/projects/api_parity.md
@@ -115,15 +115,15 @@ APIs that don't translate well to named tensors are intentionally omitted here. 
 - [ ] `permute_dims`
 - [ ] `piecewise`
 - [ ] `place`
-- [ ] `poly`
-- [ ] `polyadd`
-- [ ] `polyder`
-- [ ] `polydiv`
-- [ ] `polyfit`
-- [ ] `polyint`
-- [ ] `polymul`
-- [ ] `polysub`
-- [ ] `polyval`
+- [x] `poly`
+- [x] `polyadd`
+- [x] `polyder`
+- [x] `polydiv`
+- [x] `polyfit`
+- [x] `polyint`
+- [x] `polymul`
+- [x] `polysub`
+- [x] `polyval`
 - [ ] `pow`
 - [ ] `promote_types`
 - [ ] `put`
@@ -134,7 +134,7 @@ APIs that don't translate well to named tensors are intentionally omitted here. 
 - [ ] `resize`
 - [ ] `result_type`
 - [ ] `rollaxis`
-- [ ] `roots`
+- [x] `roots`
 - [ ] `rot90`
 - [ ] `select`
 - [ ] `setdiff1d`
@@ -148,7 +148,7 @@ APIs that don't translate well to named tensors are intentionally omitted here. 
 - [ ] `tri`
 - [ ] `tril_indices`
 - [ ] `tril_indices_from`
-- [ ] `trim_zeros`
+- [x] `trim_zeros`
 - [ ] `triu_indices`
 - [ ] `triu_indices_from`
 - [ ] `union1d`
@@ -156,7 +156,7 @@ APIs that don't translate well to named tensors are intentionally omitted here. 
 - [ ] `unravel_index`
 - [ ] `unstack`
 - [ ] `unwrap`
-- [ ] `vander`
+- [x] `vander`
 - [ ] `vsplit`
 - [ ] `vstack`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -270,6 +270,21 @@ These are all more or less directly from JAX's NumPy API.
 ::: haliax.subtract
 ::: haliax.true_divide
 
+### Polynomial Operations
+
+::: haliax.poly
+::: haliax.polyadd
+::: haliax.polysub
+::: haliax.polymul
+::: haliax.polydiv
+::: haliax.polyint
+::: haliax.polyder
+::: haliax.polyval
+::: haliax.polyfit
+::: haliax.roots
+::: haliax.trim_zeros
+::: haliax.vander
+
 ### Other Operations
 
 ::: haliax.bincount

--- a/src/haliax/__init__.py
+++ b/src/haliax/__init__.py
@@ -89,6 +89,20 @@ from .ops import (
     bincount,
     where,
 )
+from .poly import (
+    poly,
+    polyadd,
+    polysub,
+    polymul,
+    polydiv,
+    polyint,
+    polyder,
+    polyval,
+    polyfit,
+    roots,
+    trim_zeros,
+    vander,
+)
 from .partitioning import auto_sharded, axis_mapping, fsdp, named_jit, shard, shard_with_axis_mapping
 from .specialized_fns import top_k
 from .types import Scalar
@@ -1206,6 +1220,18 @@ __all__ = [
     "clip",
     "tril",
     "triu",
+    "poly",
+    "polyadd",
+    "polysub",
+    "polymul",
+    "polydiv",
+    "polyint",
+    "polyder",
+    "polyval",
+    "polyfit",
+    "roots",
+    "trim_zeros",
+    "vander",
     "add",
     "arctan2",
     "bitwise_and",

--- a/src/haliax/poly.py
+++ b/src/haliax/poly.py
@@ -1,0 +1,304 @@
+"""Polynomial helpers for :mod:`haliax`.
+
+This module provides NamedArray-aware wrappers around :mod:`jax.numpy`'s
+polynomial utilities.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, overload
+
+import jax.numpy as jnp
+from jaxtyping import Array, ArrayLike
+
+from .axis import Axis, AxisSelector, axis_name
+from .core import NamedArray, NamedOrNumeric
+from .wrap import unwrap_namedarrays
+
+DEFAULT_POLY_AXIS_NAME = "degree"
+"""Default name used for polynomial coefficient axes when none is provided."""
+
+
+def _poly_axis_from_input(p: NamedArray | ArrayLike, size: int) -> Axis:
+    if isinstance(p, NamedArray):
+        if p.ndim != 1:
+            raise ValueError("Polynomial coefficient arrays must be 1D")
+        return p.axes[0].resize(size)
+    else:
+        return Axis(DEFAULT_POLY_AXIS_NAME, size)
+
+
+def poly(seq_of_zeros: NamedArray | ArrayLike) -> NamedArray:
+    """Named version of [jax.numpy.poly][].
+
+    If ``seq_of_zeros`` is not a [haliax.NamedArray][], the returned coefficient axis
+    is named ``degree``.
+    """
+
+    (roots,) = unwrap_namedarrays(seq_of_zeros)
+    result = jnp.poly(roots)
+    axis = _poly_axis_from_input(seq_of_zeros, result.shape[0])
+    return NamedArray(result, (axis,))
+
+
+def polyadd(p1: NamedArray | ArrayLike, p2: NamedArray | ArrayLike) -> NamedArray:
+    """Named version of [jax.numpy.polyadd][].
+
+    If neither input is a [haliax.NamedArray][], the coefficient axis is named
+    ``degree``; otherwise the axis from the NamedArray input is reused (resized as
+    needed).
+    """
+
+    a1, a2 = unwrap_namedarrays(p1, p2)
+    result = jnp.polyadd(a1, a2)
+    axis = _poly_axis_from_input(p1 if isinstance(p1, NamedArray) else p2, result.shape[0])
+    return NamedArray(result, (axis,))
+
+
+def polysub(p1: NamedArray | ArrayLike, p2: NamedArray | ArrayLike) -> NamedArray:
+    """Named version of [jax.numpy.polysub][].
+
+    If neither input is a [haliax.NamedArray][], the coefficient axis is named
+    ``degree``; otherwise the axis from the NamedArray input is reused (resized as
+    needed).
+    """
+
+    a1, a2 = unwrap_namedarrays(p1, p2)
+    result = jnp.polysub(a1, a2)
+    axis = _poly_axis_from_input(p1 if isinstance(p1, NamedArray) else p2, result.shape[0])
+    return NamedArray(result, (axis,))
+
+
+def polymul(p1: NamedArray | ArrayLike, p2: NamedArray | ArrayLike) -> NamedArray:
+    """Named version of [jax.numpy.polymul][].
+
+    If neither input is a [haliax.NamedArray][], the coefficient axis is named
+    ``degree``; otherwise the axis from the NamedArray input is reused (resized as
+    needed).
+    """
+
+    a1, a2 = unwrap_namedarrays(p1, p2)
+    result = jnp.polymul(a1, a2)
+    axis = _poly_axis_from_input(p1 if isinstance(p1, NamedArray) else p2, result.shape[0])
+    return NamedArray(result, (axis,))
+
+
+def polydiv(p1: NamedArray | ArrayLike, p2: NamedArray | ArrayLike) -> tuple[NamedArray, NamedArray]:
+    """Named version of [jax.numpy.polydiv][].
+
+    The quotient and remainder reuse the coefficient axis from the NamedArray input
+    when available; otherwise their coefficient axes are named ``degree``.
+    """
+
+    a1, a2 = unwrap_namedarrays(p1, p2)
+    q, r = jnp.polydiv(a1, a2)
+    base = p1 if isinstance(p1, NamedArray) else p2
+    axis_q = _poly_axis_from_input(base, q.shape[0])
+    axis_r = _poly_axis_from_input(base, r.shape[0])
+    return NamedArray(q, (axis_q,)), NamedArray(r, (axis_r,))
+
+
+def polyint(p: NamedArray | ArrayLike, m: int = 1, k: ArrayLike | NamedArray | None = None) -> NamedArray:
+    """Named version of [jax.numpy.polyint][].
+
+    If ``p`` is not a [haliax.NamedArray][], the integrated polynomial uses a
+    coefficient axis named ``degree``.
+    """
+
+    (arr,) = unwrap_namedarrays(p)
+    k_arr = None
+    if k is not None:
+        (k_arr,) = unwrap_namedarrays(k)
+    result = jnp.polyint(arr, m=m, k=k_arr)
+    axis = _poly_axis_from_input(p, result.shape[0])
+    return NamedArray(result, (axis,))
+
+
+def polyder(p: NamedArray | ArrayLike, m: int = 1) -> NamedArray:
+    """Named version of [jax.numpy.polyder][].
+
+    If ``p`` is not a [haliax.NamedArray][], the differentiated polynomial uses a
+    coefficient axis named ``degree``.
+    """
+
+    (arr,) = unwrap_namedarrays(p)
+    result = jnp.polyder(arr, m=m)
+    axis = _poly_axis_from_input(p, result.shape[0])
+    return NamedArray(result, (axis,))
+
+
+def polyval(p: NamedArray | ArrayLike, x: NamedOrNumeric) -> NamedOrNumeric:
+    """Named version of [jax.numpy.polyval][].
+
+    When ``x`` is a [haliax.NamedArray][], the returned array reuses ``x``'s axes.
+    Otherwise a regular :mod:`jax.numpy` array is returned.
+    """
+
+    arr_p, arr_x = unwrap_namedarrays(p, x)
+    result = jnp.polyval(arr_p, arr_x)
+    if isinstance(x, NamedArray):
+        return NamedArray(result, x.axes)
+    else:
+        return result
+
+
+@overload
+def polyfit(
+    x: NamedArray | ArrayLike,
+    y: NamedArray | ArrayLike,
+    deg: int,
+    rcond: ArrayLike | None = ...,
+    full: Literal[False] = ...,
+    w: NamedArray | ArrayLike | None = ...,
+    cov: Literal[False] = ...,
+) -> NamedArray:
+    ...
+
+
+@overload
+def polyfit(
+    x: NamedArray | ArrayLike,
+    y: NamedArray | ArrayLike,
+    deg: int,
+    rcond: ArrayLike | None = ...,
+    full: Literal[True] = ...,
+    w: NamedArray | ArrayLike | None = ...,
+    cov: Literal[False] = ...,
+) -> tuple[NamedArray, Array, Array, Array, Array]:
+    ...
+
+
+@overload
+def polyfit(
+    x: NamedArray | ArrayLike,
+    y: NamedArray | ArrayLike,
+    deg: int,
+    rcond: ArrayLike | None = ...,
+    full: Literal[False] = ...,
+    w: NamedArray | ArrayLike | None = ...,
+    cov: Literal[True] = ...,
+) -> tuple[NamedArray, NamedArray]:
+    ...
+
+
+@overload
+def polyfit(
+    x: NamedArray | ArrayLike,
+    y: NamedArray | ArrayLike,
+    deg: int,
+    rcond: ArrayLike | None = ...,
+    full: Literal[True] = ...,
+    w: NamedArray | ArrayLike | None = ...,
+    cov: Literal[True] = ...,
+) -> tuple[NamedArray, Array, Array, Array, Array]:
+    ...
+
+
+def polyfit(
+    x: NamedArray | ArrayLike,
+    y: NamedArray | ArrayLike,
+    deg: int,
+    rcond: ArrayLike | None = None,
+    full: bool = False,
+    w: NamedArray | ArrayLike | None = None,
+    cov: bool = False,
+) -> NamedArray | tuple:
+    """Named version of [jax.numpy.polyfit][].
+
+    If neither ``x`` nor ``y`` is a [haliax.NamedArray][], the fitted coefficients
+    use a coefficient axis named ``degree``; otherwise the axis from the NamedArray
+    input is reused. When ``cov`` is ``True``, the returned covariance matrix is
+    wrapped in a [haliax.NamedArray][] whose row axis matches the coefficient
+    axis and whose column axis uses the same name with a ``"_cov"`` suffix.
+    """
+
+    x_arr, y_arr = unwrap_namedarrays(x, y)
+    rcond_arr = None
+    if rcond is not None:
+        (rcond_arr,) = unwrap_namedarrays(rcond)
+    w_arr = None
+    if w is not None:
+        (w_arr,) = unwrap_namedarrays(w)
+    result = jnp.polyfit(x_arr, y_arr, deg, rcond=rcond_arr, full=full, w=w_arr, cov=cov)
+
+    def wrap_coeffs(coeffs):
+        base = x if isinstance(x, NamedArray) else y
+        axis = _poly_axis_from_input(base, coeffs.shape[0])
+        return NamedArray(coeffs, (axis,))
+
+    if full:
+        coeffs = wrap_coeffs(result[0])
+        return (coeffs,) + result[1:]
+    coeffs = wrap_coeffs(result if not cov else result[0])
+    if cov:
+        cov_axis = coeffs.axes[0]
+        return coeffs, NamedArray(result[1], (cov_axis, cov_axis.alias(f"{cov_axis.name}_cov")))
+    return coeffs
+
+
+def roots(p: NamedArray | ArrayLike) -> NamedArray:
+    """Named version of [jax.numpy.roots][].
+
+    If ``p`` is not a [haliax.NamedArray][], the root axis is named ``degree``.
+    """
+
+    (arr,) = unwrap_namedarrays(p)
+    result = jnp.roots(arr)
+    axis = _poly_axis_from_input(p, result.shape[0])
+    return NamedArray(result, (axis,))
+
+
+def trim_zeros(f: NamedArray | ArrayLike, trim: str = "fb") -> NamedArray:
+    """Named version of [jax.numpy.trim_zeros][].
+
+    If ``f`` is not a [haliax.NamedArray][], the trimmed coefficient axis is named
+    ``degree``.
+    """
+
+    (arr,) = unwrap_namedarrays(f)
+    result = jnp.trim_zeros(arr, trim=trim)
+    axis = _poly_axis_from_input(f, result.shape[0])
+    return NamedArray(result, (axis,))
+
+
+def vander(x: NamedArray, degree: AxisSelector) -> NamedArray:
+    """Named version of [jax.numpy.vander][].
+
+    Args:
+        x: Input array of shape ``(n,)``.
+        degree: Axis for the polynomial degree in the output. If a string is
+            provided, an axis with that name and size ``n`` is created.
+
+    Returns:
+        Vandermonde matrix with row axis from ``x`` and the provided degree axis.
+    """
+
+    if x.ndim != 1:
+        raise ValueError("vander only supports 1D input")
+
+    if isinstance(degree, Axis):
+        N = degree.size
+        deg_axis = degree
+    else:
+        N = x.axes[0].size
+        deg_axis = Axis(axis_name(degree), N)
+
+    result = jnp.vander(x.array, N=N)
+    return NamedArray(result, (x.axes[0], deg_axis))
+
+
+__all__ = [
+    "DEFAULT_POLY_AXIS_NAME",
+    "poly",
+    "polyadd",
+    "polysub",
+    "polymul",
+    "polydiv",
+    "polyint",
+    "polyder",
+    "polyval",
+    "polyfit",
+    "roots",
+    "trim_zeros",
+    "vander",
+]

--- a/tests/test_poly_ops.py
+++ b/tests/test_poly_ops.py
@@ -1,0 +1,131 @@
+import jax.numpy as jnp
+from typing import cast, no_type_check
+import haliax as hax
+from haliax import Axis
+from haliax.core import NamedArray
+
+
+def _assert_coefficients(coeffs: NamedArray, expected: jnp.ndarray, axis: Axis) -> None:
+    assert jnp.allclose(coeffs.array, expected)  # type: ignore[union-attr]
+    assert coeffs.axes[0] == axis.resize(coeffs.array.shape[0])  # type: ignore[union-attr]
+
+
+def _assert_covariance_matrix(cov: NamedArray, axis: Axis, expected: jnp.ndarray) -> None:
+    assert jnp.allclose(cov.array, expected)  # type: ignore[union-attr]
+    assert cov.axes[0] == axis  # type: ignore[union-attr]
+    assert cov.axes[1].name == f"{axis.name}_cov"  # type: ignore[union-attr]
+    assert cov.axes[1].size == axis.size  # type: ignore[union-attr]
+
+
+def test_poly():
+    R = Axis("R", 3)
+    roots = hax.named([1.0, 2.0, 3.0], (R,))
+    coeffs = hax.poly(roots)
+    assert jnp.allclose(coeffs.array, jnp.poly(roots.array))
+    assert coeffs.axes[0] == R.resize(coeffs.array.shape[0])
+
+
+def test_poly_arithmetic():
+    C1 = Axis("C1", 4)
+    p = hax.named([1.0, 0.0, -2.0, 1.0], (C1,))
+    C2 = Axis("C2", 2)
+    q = hax.named([1.0, -1.0], (C2,))
+
+    add = hax.polyadd(p, q)
+    assert jnp.allclose(add.array, jnp.polyadd(p.array, q.array))
+    assert add.axes[0] == C1.resize(add.array.shape[0])
+
+    sub = hax.polysub(p, q)
+    assert jnp.allclose(sub.array, jnp.polysub(p.array, q.array))
+    assert sub.axes[0] == C1.resize(sub.array.shape[0])
+
+    mul = hax.polymul(p, q)
+    assert jnp.allclose(mul.array, jnp.polymul(p.array, q.array))
+    assert mul.axes[0] == C1.resize(mul.array.shape[0])
+
+    div_q, div_r = hax.polydiv(p, q)
+    exp_q, exp_r = jnp.polydiv(p.array, q.array)
+    assert jnp.allclose(div_q.array, exp_q)
+    assert jnp.allclose(div_r.array, exp_r)
+    assert div_q.axes[0] == C1.resize(div_q.array.shape[0])
+    assert div_r.axes[0] == C1.resize(div_r.array.shape[0])
+
+
+def test_poly_int_der():
+    C = Axis("C", 4)
+    p = hax.named([1.0, 0.0, -2.0, 1.0], (C,))
+
+    d = hax.polyder(p)
+    i = hax.polyint(p)
+
+    assert jnp.allclose(d.array, jnp.polyder(p.array))
+    assert jnp.allclose(i.array, jnp.polyint(p.array))
+    assert d.axes[0] == C.resize(d.array.shape[0])
+    assert i.axes[0] == C.resize(i.array.shape[0])
+
+
+@no_type_check
+def test_polyval_polyfit():
+    C = Axis("C", 4)
+    p = hax.named([1.0, 0.0, -2.0, 1.0], (C,))
+
+    X = Axis("X", 5)
+    x = hax.arange(X, dtype=jnp.float64)
+    y = hax.polyval(p, x)
+
+    pv = cast(NamedArray, hax.polyval(p, x))
+    assert jnp.allclose(pv.array, jnp.polyval(p.array, x.array))
+
+    fit = cast(NamedArray, hax.polyfit(x, y, 3))
+    assert jnp.allclose(fit.array, p.array, atol=1e-5)
+    assert fit.axes[0] == X.resize(fit.array.shape[0])
+
+    full_fit = hax.polyfit(x, y, 3, full=True)
+    assert isinstance(full_fit, tuple)
+    coeffs_full = full_fit[0]
+    assert isinstance(coeffs_full, NamedArray)
+    coeffs_full = cast(NamedArray, coeffs_full)
+    exp_full = jnp.polyfit(x.array, y.array, 3, full=True)
+    _assert_coefficients(coeffs_full, exp_full[0], X)  # type: ignore[union-attr]
+    for res, exp in zip(full_fit[1:], exp_full[1:]):
+        assert jnp.allclose(res, exp)
+
+    cov_fit = hax.polyfit(x, y, 3, cov=True)
+    assert isinstance(cov_fit, tuple)
+    coeffs_cov = cov_fit[0]
+    cov = cov_fit[1]
+    assert isinstance(coeffs_cov, NamedArray)
+    assert isinstance(cov, NamedArray)
+    coeffs_cov = cast(NamedArray, coeffs_cov)
+    cov = cast(NamedArray, cov)
+    exp_coeffs, exp_cov = jnp.polyfit(x.array, y.array, 3, cov=True)
+    _assert_coefficients(coeffs_cov, exp_coeffs, X)  # type: ignore[union-attr]
+    _assert_covariance_matrix(cov, coeffs_cov.axes[0], exp_cov)  # type: ignore[union-attr]
+
+
+
+def test_poly_roots_trim_vander():
+    C = Axis("C", 4)
+    p = hax.named([1.0, 0.0, -2.0, 1.0], (C,))
+
+    r = hax.roots(p)
+    assert jnp.allclose(r.array, jnp.roots(p.array))
+    assert r.axes[0] == C.resize(r.array.shape[0])
+
+    C2 = Axis("C2", 4)
+    p2 = hax.named([0.0, 0.0, 1.0, 2.0], (C2,))
+    t = hax.trim_zeros(p2)
+    assert jnp.allclose(t.array, jnp.trim_zeros(p2.array))
+    assert t.axes[0] == C2.resize(t.array.shape[0])
+
+    X = Axis("X", 3)
+    x = hax.named([1.0, 2.0, 3.0], (X,))
+    D = Axis("D", 3)
+    v = hax.vander(x, D)
+    assert jnp.allclose(v.array, jnp.vander(x.array, N=3))
+    assert v.axes == (X, D)
+
+    v2 = hax.vander(x, "E")
+    assert jnp.allclose(v2.array, jnp.vander(x.array))
+    assert v2.axes[0] == X
+    assert v2.axes[1] == Axis("E", X.size)


### PR DESCRIPTION
## Summary
- stop re-exporting `DEFAULT_POLY_AXIS_NAME` from the top-level API
- add typed overloads and covariance handling to `haliax.poly.polyfit`, including a dedicated name for the covariance column axis
- extend the polynomial tests to cover the full and covariance return modes while tolerating mypy's limited knowledge of NamedArray

## Testing
- `uv run pre-commit run --all-files`
- `XLA_FLAGS=--xla_force_host_platform_device_count=8 PYTHONPATH=tests:src:. uv run pytest tests/test_poly_ops.py`


------
https://chatgpt.com/codex/tasks/task_e_68c3d208bd088331ba37b1e8fe12c012