### PR TITLE
feat: Add Open Athena AI Foundation as author

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -3,3 +3,4 @@
 The Levanter Authors currently include:
 
 - The Board of Trustees of the Leland Stanford Junior University
+- Open Athena AI Foundation, Inc.


### PR DESCRIPTION
Adds Open Athena AI Foundation, Inc. to the list of authors in AUTHORS.md.